### PR TITLE
Fix MCP23008 example

### DIFF
--- a/components/mcp230xx.rst
+++ b/components/mcp230xx.rst
@@ -36,8 +36,7 @@ The MCP23008 component (`datasheet <http://ww1.microchip.com/downloads/en/device
           mcp23008: mcp23008_hub
           # Use pin number 0
           number: 0
-          # One of INPUT, INPUT_PULLUP or OUTPUT
-          mode: INPUT_PULLUP
+          mode: OUTPUT
           inverted: False
 
     # Individual inputs


### PR DESCRIPTION
## Description
Change the pin mode from INPUT_PULLUP to OUTPUT for the switch in the MCP23008 example

## Fixes
**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [x] Link added in `/index.rst` when creating new documents for new components or cookbook.
